### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ python setup.py build_ext --inplace
 This package provides one simple function to reduce a given mesh
 
 ```python
-    from quad_mesh_simplify import simplify_mesh
+    from quad_mesh_simplify.simplify import simplify_mesh
 ```
 
 To reduce a mesh call


### PR DESCRIPTION
In the README.md under Usage,

`from quad_mesh_simplify import simplify_mesh`

is shown. It is wrong and the corrected version should be 

```from quad_mesh_simplify.simplify import simplify_mesh```

I am doing this because that error wasted a lot of time but I really admire your implementation.
