### PR TITLE
Correct the package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ src_path = osp.join(osp.dirname(osp.abspath(__file__)), 'quad_mesh_simplify')
 
 ext_modules = [
 	Extension(
-		'simplify',
+		'quad_mesh_simplify',
 		[osp.join(src_path, 'c', f) for f in files] + [osp.join(src_path,'simplify.pyx')],
 		# extra_compile_args=['-fopenmp'],
 		# extra_link_args=['-fopenmp'],


### PR DESCRIPTION
Hi Jannes, thanks a lot for this useful tool. I just found that there is a typo in `setup.py`, which makes the package name to be `simplify` instead of `quad_mesh_simplify`. This PR fixes it:

https://github.com/jannessm/quadric-mesh-simplification/blob/5954cd5bee4de540c9b015350ec0e416b49b0131/setup.py#L32

Feel free to let me know if you have any questions. Thanks